### PR TITLE
Simplify `WorkflowOutStream` wrapper class

### DIFF
--- a/jupyter_workflow/ipython/iostream.py
+++ b/jupyter_workflow/ipython/iostream.py
@@ -1,6 +1,3 @@
-import os
-import sys
-import threading
 from contextvars import ContextVar
 from functools import partial
 from io import StringIO
@@ -9,12 +6,18 @@ from typing import MutableMapping
 from ipykernel.iostream import OutStream
 
 
+def add_cell_id_hook(msg: MutableMapping, cell_id: ContextVar):
+    msg["content"]["metadata"]["cell_id"] = cell_id.get()
+    return msg
+
+
 class WorkflowOutStream(OutStream):
     def __init__(self, *args, **kwargs):
         self._buffer_dict: MutableMapping[str, StringIO] = {}
         self._parent_headers: MutableMapping[str, MutableMapping] = {}
         self.cell_id: ContextVar[str] = ContextVar("cell_id", default="")
         super().__init__(*args, **kwargs)
+        self.register_hook(partial(add_cell_id_hook, cell_id=self.cell_id))
 
     @property
     def _buffer(self):
@@ -27,63 +30,6 @@ class WorkflowOutStream(OutStream):
     @_buffer.deleter
     def _buffer(self):
         del self._buffer_dict[self.cell_id.get()]
-
-    def _flush(self, cell_id: str = None):
-        self._flush_pending = False
-        self._subprocess_flush_pending = False
-
-        if self.echo is not None:
-            try:
-                self.echo.flush()
-            except OSError as e:
-                if self.echo is not sys.__stderr__:
-                    print(f"Flush failed: {e}", file=sys.__stderr__)
-
-        if cell_id:
-            self.set_cell_id(cell_id)
-
-        data = self._flush_buffer()
-        if data:
-            self.session.pid = os.getpid()
-            content = {
-                "name": self.name,
-                "metadata": {"cell_id": self.cell_id.get()},
-                "text": data,
-            }
-            self.session.send(
-                self.pub_thread,
-                "stream",
-                content=content,
-                parent=self.parent_header,
-                ident=self.topic,
-            )
-
-    def _schedule_flush(self):
-        if self._flush_pending:
-            return
-        self._flush_pending = True
-
-        def _schedule_in_thread():
-            self._io_loop.call_later(
-                self.flush_interval, partial(self._flush, cell_id=self.cell_id.get())
-            )
-
-        self.pub_thread.schedule(_schedule_in_thread)
-
-    def flush(self):
-        if (
-            self.pub_thread
-            and self.pub_thread.thread is not None
-            and self.pub_thread.thread.is_alive()
-            and self.pub_thread.thread.ident != threading.current_thread().ident
-        ):
-            self.pub_thread.schedule(partial(self._flush, cell_id=self.cell_id.get()))
-            evt = threading.Event()
-            self.pub_thread.schedule(evt.set)
-            if not evt.wait(self.flush_timeout):
-                print("IOStream.flush timed out", file=sys.__stderr__)
-        else:
-            self._flush()
 
     def delete_parent(self, parent):
         if "workflow" in parent["content"]:
@@ -111,29 +57,3 @@ class WorkflowOutStream(OutStream):
         if "workflow" in parent["content"]:
             self.set_cell_id(parent["content"]["workflow"].get("cell_id", ""))
         super().set_parent(parent)
-
-    def write(self, string: str) -> int:
-        if not isinstance(string, str):
-            raise TypeError(f"write() argument must be str, not {type(string)}")
-        if self.echo is not None:
-            try:
-                self.echo.write(string)
-            except OSError as e:
-                if self.echo is not sys.__stderr__:
-                    print(f"Write failed: {e}", file=sys.__stderr__)
-        if self.pub_thread is None:
-            raise ValueError("I/O operation on closed file")
-        else:
-            is_child = not self._is_master_process()
-            with self._buffer_lock:
-                self._buffer.write(string)
-            if is_child:
-                if self._subprocess_flush_pending:
-                    return
-                self._subprocess_flush_pending = True
-                self.pub_thread.schedule(
-                    partial(self._flush, cell_id=self.cell_id.get())
-                )
-            else:
-                self._schedule_flush()
-        return len(string)

--- a/jupyter_workflow/ipython/shell.py
+++ b/jupyter_workflow/ipython/shell.py
@@ -101,7 +101,7 @@ def _get_stdout(token_value: Any):
 
 
 def build_context() -> StreamFlowContext:
-    context: StreamFlowContext = StreamFlowContext(os.getcwd())
+    context: StreamFlowContext = StreamFlowContext({"path": os.getcwd()})
     context.checkpoint_manager = DummyCheckpointManager(context)
     context.database = SqliteDatabase(context, ":memory:")
     context.data_manager = DefaultDataManager(context)


### PR DESCRIPTION
The new veraion of the `OutStream` class provided by `ipykernel` supports registering message hooks. Therefore, the implementation of `WorkflowOutStream` can leverage a hook to manage the `cell_id` parameter, using the same strategy adopted for display hooks.