### PR TITLE
Add `codecov.yml` config file

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -88,7 +88,7 @@ jobs:
       - name: "Download artifacts"
         uses: actions/download-artifact@v3
       - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+codecov:
+  require_ci_to_pass: true
+coverage:
+  status:
+    project: off
+    patch: off


### PR DESCRIPTION
This commit fixes CodeCov coverage upload by switching to repository-based upload and adding a `codecov.yml` configuration file.