### PR TITLE
Added `isort` to CI/CD checks

### DIFF
--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -10,3 +10,6 @@ query-filters:
   # Reason: false positive on HasTraits class hierarchy
   - exclude:
       id: py/missing-call-to-init
+  # Reason: no support for the TYPE_CHECKING directive (issue 4258)
+  - exclude:
+      id:  py/unsafe-cyclic-import

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,11 @@ flake8:
 	flake8 jupyter_workflow tests
 
 format:
+	isort jupyter_workflow tests
 	black jupyter_workflow tests
 
 format-check:
+	isort --check-only jupyter_workflow tests
 	black --diff --check jupyter_workflow tests
 
 pyupgrade:

--- a/jupyter_workflow/client/client.py
+++ b/jupyter_workflow/client/client.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import MutableMapping, MutableSequence
 from contextvars import ContextVar
 from functools import partial
 from typing import Any, cast
-from collections.abc import MutableMapping, MutableSequence
 
 import traitlets
 from jupyter_client import AsyncKernelClient, AsyncKernelManager, KernelManager

--- a/jupyter_workflow/config/validator.py
+++ b/jupyter_workflow/config/validator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from typing import Any
 from collections.abc import MutableMapping
+from typing import Any
 
 from jsonschema.validators import validator_for
 from streamflow.core.exception import WorkflowDefinitionException

--- a/jupyter_workflow/ipython/displayhook.py
+++ b/jupyter_workflow/ipython/displayhook.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from contextvars import ContextVar
 from functools import partial
-from collections.abc import MutableMapping
 
 from ipykernel.displayhook import ZMQShellDisplayHook
 from ipykernel.zmqshell import ZMQDisplayPublisher

--- a/jupyter_workflow/ipython/iostream.py
+++ b/jupyter_workflow/ipython/iostream.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from contextvars import ContextVar
 from functools import partial
 from io import StringIO
 from typing import cast
-from collections.abc import MutableMapping
 
 from ipykernel.iostream import IOPubThread, OutStream
 

--- a/jupyter_workflow/ipython/shell.py
+++ b/jupyter_workflow/ipython/shell.py
@@ -12,9 +12,9 @@ from typing import Any, cast
 
 import streamflow.log_handler
 import traitlets
+from ipykernel.zmqshell import ZMQInteractiveShell
 from IPython.core.error import InputRejected
 from IPython.core.interactiveshell import ExecutionResult
-from ipykernel.zmqshell import ZMQInteractiveShell
 from streamflow.core import utils
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.deployment import ExecutionLocation, LocalTarget

--- a/jupyter_workflow/streamflow/step.py
+++ b/jupyter_workflow/streamflow/step.py
@@ -6,8 +6,8 @@ import codeop
 import json
 import sys
 from abc import ABC, abstractmethod
-from typing import Any, cast
 from collections.abc import MutableMapping
+from typing import Any, cast
 
 import cloudpickle as pickle
 from streamflow.core.command import CommandOutput, CommandOutputProcessor

--- a/jupyter_workflow/streamflow/transformer.py
+++ b/jupyter_workflow/streamflow/transformer.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import ast
 import json
-from typing import Any, cast
 from collections.abc import MutableMapping, MutableSequence
+from typing import Any, cast
 
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.exception import WorkflowExecutionException

--- a/jupyter_workflow/streamflow/translator.py
+++ b/jupyter_workflow/streamflow/translator.py
@@ -8,11 +8,11 @@ import os
 import posixpath
 import string
 from collections import deque
+from collections.abc import MutableMapping, MutableSequence
 from typing import (
     Any,
     cast,
 )
-from collections.abc import MutableMapping, MutableSequence
 
 from streamflow.core import utils
 from streamflow.core.config import BindingConfig

--- a/jupyter_workflow/streamflow/utils.py
+++ b/jupyter_workflow/streamflow/utils.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import asyncio
 import builtins
 import posixpath
-from typing import Any
 from collections.abc import MutableMapping, MutableSequence
+from typing import Any
 
 from streamflow.core import utils
 from streamflow.core.context import StreamFlowContext

--- a/jupyter_workflow/streamflow/workflow.py
+++ b/jupyter_workflow/streamflow/workflow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from typing import Any
 from collections.abc import MutableMapping
+from typing import Any
 
 from streamflow.core.context import StreamFlowContext
 from streamflow.core.workflow import Workflow

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,4 +1,5 @@
 black==25.1.0
 codespell==2.4.1
 flake8-bugbear==24.12.12
+isort==6.0.1
 pyupgrade==3.19.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,6 @@ omit = [
     "jupyter_workflow/ipython/__main__.py",
     "tests/*"
 ]
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
This commit adds the `isort` utility to sort `import` statements alphabetically.