### PR TITLE
Modernize Notebook examples

### DIFF
--- a/examples/1000-genome/work/1000-genome.ipynb
+++ b/examples/1000-genome/work/1000-genome.ipynb
@@ -148,7 +148,7 @@
       }
      },
      "target": {
-      "model": "helm-1000-genome",
+      "deployment": "helm-1000-genome",
       "service": "1000-genome"
      }
     }
@@ -784,7 +784,7 @@
       }
      },
      "target": {
-      "model": "helm-1000-genome",
+      "deployment": "helm-1000-genome",
       "service": "1000-genome"
      }
     }
@@ -945,7 +945,7 @@
       }
      },
      "target": {
-      "model": "helm-1000-genome",
+      "deployment": "helm-1000-genome",
       "service": "1000-genome"
      }
     }
@@ -1043,7 +1043,7 @@
   },
   "workflow": {
    "interpreter": "ipython",
-   "models": {
+   "deployments": {
     "helm-1000-genome": {
      "config": {
       "chart": "environment/k8s/1000-genome",

--- a/examples/claire-covid/work/claire-covid.ipynb
+++ b/examples/claire-covid/work/claire-covid.ipynb
@@ -283,7 +283,7 @@
       "workdir": "/path/to/shared/workdir"
      },
      "target": {
-      "model": "cineca-marconi100"
+      "deployment": "cineca-marconi100"
      }
     }
    },
@@ -389,7 +389,7 @@
    "version": "3.8.8"
   },
   "workflow": {
-   "models": {
+   "deployments": {
     "cineca-marconi100": {
      "config": {
       "file": "environment/cineca-marconi100/slurm_template.jinja2",

--- a/examples/quantum-espresso/work/car-parrinello/car-parrinello.ipynb
+++ b/examples/quantum-espresso/work/car-parrinello/car-parrinello.ipynb
@@ -65,7 +65,7 @@
       "workdir": "/path/to/shared/workdir"
      },
      "target": {
-      "model": "qe-docker"
+      "deployment": "qe-docker"
      }
     }
    },
@@ -133,7 +133,7 @@
       "workdir": "/path/to/shared/workdir"
      },
      "target": {
-      "model": "qe-docker"
+      "deployment": "qe-docker"
      }
     }
    },
@@ -197,7 +197,7 @@
       "workdir": "/path/to/shared/workdir"
      },
      "target": {
-      "model": "qe-docker"
+      "deployment": "qe-docker"
      }
     }
    },
@@ -279,7 +279,7 @@
       "workdir": "/path/to/shared/workdir"
      },
      "target": {
-      "model": "qe-docker"
+      "deployment": "qe-docker"
      }
     }
    },
@@ -336,7 +336,7 @@
   },
   "workflow": {
    "interpreter": "/path/to/ipython/interpreter",
-   "models": {
+   "deployments": {
     "qe-docker": {
      "config": {
       "file": "environment/pbs_espresso",

--- a/examples/quantum-espresso/work/primordial-soup/primordial-soup.ipynb
+++ b/examples/quantum-espresso/work/primordial-soup/primordial-soup.ipynb
@@ -108,7 +108,7 @@
       "workdir": "/path/to/workdir"
      },
      "target": {
-      "model": "pbs-davinci"
+      "deployment": "pbs-davinci"
      }
     }
    },
@@ -173,7 +173,7 @@
       "workdir": "/path/to/workdir"
      },
      "target": {
-      "model": "pbs-davinci"
+      "deployment": "pbs-davinci"
      }
     }
    },
@@ -238,7 +238,7 @@
       "workdir": "/path/to/workdir"
      },
      "target": {
-      "model": "pbs-davinci"
+      "deployment": "pbs-davinci"
      }
     }
    },
@@ -303,7 +303,7 @@
       "workdir": "/path/to/workdir"
      },
      "target": {
-      "model": "pbs-davinci"
+      "deployment": "pbs-davinci"
      }
     }
    },
@@ -381,7 +381,7 @@
       "workdir": "/path/to/workdir"
      },
      "target": {
-      "model": "pbs-davinci"
+      "deployment": "pbs-davinci"
      }
     }
    },
@@ -478,7 +478,7 @@
       "workdir": "/path/to/workdir"
      },
      "target": {
-      "model": "pbs-davinci"
+      "deployment": "pbs-davinci"
      }
     }
    },
@@ -568,7 +568,7 @@
   },
   "workflow": {
    "interpreter": "/path/to/ipython/interpreter",
-   "models": {
+   "deployments": {
     "pbs-davinci": {
      "config": {
       "file": "/environment/pbs_espresso",

--- a/examples/tensorflow/work/tf-serve.ipynb
+++ b/examples/tensorflow/work/tf-serve.ipynb
@@ -191,7 +191,7 @@
       ]
      },
      "target": {
-      "model": "tensorflow"
+      "deployment": "tensorflow"
      }
     }
    },
@@ -349,7 +349,7 @@
       ]
      },
      "target": {
-      "model": "tf-serving",
+      "deployment": "tf-serving",
       "service": "tensorflow-serving"
      }
     }
@@ -380,7 +380,7 @@
       ]
      },
      "target": {
-      "model": "tf-serving",
+      "deployment": "tf-serving",
       "service": "tensorflow-serving"
      }
     }
@@ -464,7 +464,7 @@
    "version": "3.8.8"
   },
   "workflow": {
-   "models": {
+   "deployments": {
     "tensorflow": {
      "config": {
       "file": "environment/hpc/ssh_template.jinja2",


### PR DESCRIPTION
This commit modernizes the StreamFlow metadata in the Notebook examples, migrating the old `model` option to the new `deployment` one.